### PR TITLE
Upgrade pyo3 to version 0.12.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.5.0"
 features = ["parallel"]
 
 [dependencies.pyo3]
-version = "0.8.5"
+version = "0.12.4"
 features = ["extension-module"]
 
 [package.metadata.maturin]

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,6 +1,6 @@
 use std::io::SeekFrom;
 
-use pyo3::{IntoPy, ObjectProtocol, PyResult, Python, ToPyObject};
+use pyo3::{IntoPy, PyResult, Python, ToPyObject};
 
 fn py_seek_args_from_rust_seek(
     seek: SeekFrom,


### PR DESCRIPTION
This fixes the crashes when instantiating a class
in Python 3.9

(closes #4)