### PR TITLE
Avoid too many copies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ import shutil
 
 WHEEL_DIR = Path(os.environ.get("CARGO_TARGET_DIR", '.target')) / "wheels"
 
+Path('dist').mkdir(exist_ok=True)
 
 @nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def build_wheel(session):
@@ -21,4 +22,4 @@ def build_wheel(session):
     session.run('python', '-c', 'import lazrs')
 
     # Save the wheel as its going to be erased by the next cargo clean
-    shutil.copy(wheel, '.')
+    shutil.copy(wheel, 'dist')

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,6 +1,25 @@
 use std::io::SeekFrom;
 
+use pyo3::ffi::Py_ssize_t;
+use pyo3::PyObject;
 use pyo3::{IntoPy, PyResult, Python, ToPyObject};
+use std::os::raw::c_char;
+
+fn to_other_io_error(message: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, message)
+}
+
+fn seek_file_object(file_object: &PyObject, pos: SeekFrom) -> std::io::Result<u64> {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let args = py_seek_args_from_rust_seek(pos, py);
+    let new_pos = file_object
+        .call_method(py, "seek", args, None)
+        .and_then(|py_long| py_long.extract::<u64>(py))
+        .map_err(|_err| to_other_io_error(format!("Failed to call seek")))?;
+    Ok(new_pos)
+}
 
 fn py_seek_args_from_rust_seek(
     seek: SeekFrom,
@@ -25,6 +44,7 @@ fn py_seek_args_from_rust_seek(
 
 pub struct PyWriteableFileObject {
     file_obj: pyo3::PyObject,
+    write_fn: pyo3::PyObject,
 }
 
 impl PyWriteableFileObject {
@@ -32,58 +52,63 @@ impl PyWriteableFileObject {
         let gil = Python::acquire_gil();
         let py = gil.python();
 
-        file_obj.getattr(py, "write")?;
-        file_obj.getattr(py, "seek")?;
+        let write_fn = file_obj.getattr(py, "write")?;
 
-        Ok(Self { file_obj })
+        Ok(Self { file_obj, write_fn })
     }
 }
 
 impl std::io::Write for PyWriteableFileObject {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let gil = pyo3::Python::acquire_gil();
-        let py_bytes = pyo3::types::PyBytes::new(gil.python(), buf);
-        self.file_obj
-            .call_method1(gil.python(), "write", (py_bytes.to_object(gil.python()),))
-            .and_then(|ret_val| ret_val.extract::<usize>(gil.python()))
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, format!("{:?}", err)))
+        let py = gil.python();
+
+        let memview = unsafe {
+            let view_object = pyo3::ffi::PyMemoryView_FromMemory(
+                buf.as_ptr() as *mut c_char,
+                buf.len() as Py_ssize_t,
+                pyo3::ffi::PyBUF_READ,
+            );
+
+            pyo3::PyObject::from_owned_ptr(py, view_object)
+        };
+
+        self.write_fn
+            .call1(py, (memview,))
+            .and_then(|ret_val| ret_val.extract::<usize>(py))
+            .map_err(|_err| to_other_io_error(format!("Failed to call write")))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         let gil = pyo3::Python::acquire_gil();
-        self.file_obj.call_method0(gil.python(), "flush").unwrap();
+        self.file_obj
+            .call_method0(gil.python(), "flush")
+            .map_err(|_err| to_other_io_error(format!("Failed to call flush")))?;
         Ok(())
     }
 }
 
 impl std::io::Seek for PyWriteableFileObject {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
-        let args = py_seek_args_from_rust_seek(pos, py);
-        let new_pos = self
-            .file_obj
-            .call_method(py, "seek", args, None)
-            .unwrap()
-            .cast_as::<pyo3::types::PyLong>(py)
-            .unwrap()
-            .extract()
-            .unwrap();
-        Ok(new_pos)
+        seek_file_object(&self.file_obj, pos)
     }
 }
 
 pub struct PyReadableFileObject {
+    file_object: pyo3::PyObject,
     read_fn: pyo3::PyObject,
-    seek_fn: pyo3::PyObject,
+    readinto_fn: Option<pyo3::PyObject>,
 }
 
 impl PyReadableFileObject {
     pub fn new(py: pyo3::Python, object: pyo3::PyObject) -> PyResult<Self> {
         let read_fn = object.getattr(py, "read")?;
-        let seek_fn = object.getattr(py, "seek")?;
-        Ok(Self { read_fn, seek_fn })
+        let readinto_fn = object.getattr(py, "readinto").ok();
+        Ok(Self {
+            file_object: object,
+            read_fn,
+            readinto_fn,
+        })
     }
 }
 
@@ -91,46 +116,49 @@ impl std::io::Read for PyReadableFileObject {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let num_bytes_to_read: pyo3::PyObject = buf.len().into_py(py);
-        let ret_obj = match self.read_fn.call(py, (num_bytes_to_read,), None) {
-            Ok(ret_val) => ret_val,
-            Err(err) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("{:?}", err),
-                ));
-            }
-        };
 
-        match ret_obj.cast_as::<pyo3::types::PyBytes>(py) {
-            Ok(py_bytes) => {
-                let read_bytes = py_bytes.as_bytes();
-                let shortest = std::cmp::min(buf.len(), read_bytes.len());
-                buf[..shortest].copy_from_slice(read_bytes);
-                Ok(read_bytes.len())
+        if let Some(ref readinto) = self.readinto_fn {
+            let memview = unsafe {
+                let view_object = pyo3::ffi::PyMemoryView_FromMemory(
+                    buf.as_mut_ptr() as *mut c_char,
+                    buf.len() as Py_ssize_t,
+                    pyo3::ffi::PyBUF_WRITE,
+                );
+
+                pyo3::PyObject::from_owned_ptr(py, view_object)
+            };
+            readinto
+                .call1(py, (memview,))
+                .and_then(|num_bytes_read| num_bytes_read.extract::<usize>(py))
+                .map_err(|_err| to_other_io_error(format!("Failed to use readinto to read bytes")))
+        } else {
+            let num_bytes_to_read: pyo3::PyObject = buf.len().into_py(py);
+
+            let object = self
+                .read_fn
+                .call1(py, (num_bytes_to_read,))
+                .map_err(|_err| {
+                    std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to call read"))
+                })?;
+
+            match object.cast_as::<pyo3::types::PyBytes>(py) {
+                Ok(py_bytes) => {
+                    let read_bytes = py_bytes.as_bytes();
+                    let shortest = std::cmp::min(buf.len(), read_bytes.len());
+                    buf[..shortest].copy_from_slice(read_bytes);
+                    Ok(read_bytes.len())
+                }
+                Err(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("read did not return bytes"),
+                )),
             }
-            Err(err) => Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("{:?}", err),
-            )),
         }
     }
 }
 
 impl std::io::Seek for PyReadableFileObject {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
-        let args = py_seek_args_from_rust_seek(pos, py);
-        let new_pos = self
-            .seek_fn
-            .call(py, args, None)
-            .expect("Failed to call seek")
-            .cast_as::<pyo3::types::PyLong>(py)
-            .expect("Failed to cast to pylong")
-            .extract()
-            .expect("Failed to cast to u64");
-        Ok(new_pos)
+        seek_file_object(&self.file_object, pos)
     }
 }


### PR DESCRIPTION
Use memoryviews + readinto when reading if possible,
else fallback to the previous way.

When writing use memoryview to avoid temporarly copying the slice
to bytes before calling python's write