### PR TITLE
Build Linux wheels in Docker container for manylinux2010 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,14 @@ jobs:
           override: true
 
       - name: Build
-        run: maturin build --release
+        if:  matrix.os == 'ubuntu-latest'
+        run: docker run --rm -v $(pwd):/io ghcr.io/pyo3/maturin build
 
+      - name: Build
+        if:  matrix.os != 'ubuntu-latest'
+        run: maturin build --compatibility manylinux2010
+
+      # Upload the wheels of the build for manual download/inspection
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./target/wheels/lazrs*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,13 @@ jobs:
 #          Get-ChildItem -Path .\target\wheels\*.whl | ForEach-Object { twine upload -u __token__ -p ${{ secrets.PYPI }} $_.FullName }
 
       - name: Publish to PyPi
-        if:  matrix.os != 'windows-latest'
+        if:  matrix.os == 'ubuntu-latest'
+        run: |
+          docker run --rm -v $(pwd):/io ghcr.io/pyo3/maturin build --release --interpreter python${{ matrix.python-version }}
+          twine upload -u __token__ -p ${{ secrets.PYPI }} target/wheels/lazrs*.whl
+
+      - name: Publish to PyPi
+        if:  matrix.os == 'macos-latest'
         run: |
           maturin build --release --interpreter python${{ matrix.python-version }}
           twine upload -u __token__ -p ${{ secrets.PYPI }} target/wheels/lazrs*.whl


### PR DESCRIPTION
This changes the `maturin` build process in CI to allow compatibility with `manylinux` distributions that are older than the host system. It follows the recommendations from the [maturin documentation](https://maturin.rs/distribution.html#build-wheels) and builds the Linux wheels inside a Docker container provided by pyo3.

This of course introduces some platform-specific logic, as only Linux builds are affected. A potential solution to reduce the number of these platform-specific code paths could be to use [cibuildwheel](https://github.com/pypa/cibuildwheel), but you have to decide that for yourself.

I took the liberty to add an `upload-artifact` step to the CI build so that the built wheels can be downloaded and manually tested. If you want me to remove it, I can do so.

This fixes #10.