### PR TITLE
Build sdist explicitly with manylinux 2014

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           command: sdist
+          manylinux: 2014
           args: --out dist
 
       # Upload the wheels of the build for manual download/inspection


### PR DESCRIPTION
Seeing if this helps with the ppc64le pypy3.9 build failures at https://github.com/conda-forge/lazrs-python-feedstock/pull/14.

Actually not 100% sure if this change work, because running `maturin sdist --help` doesn't mention anything about manylinux, so not sure what it's defaulting to. It might be that this just gets ignored by https://github.com/PyO3/maturin-action/tree/v1.32.0#inputs.