### PR TITLE
fix LazrsError base package name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 
 mod adapters;
 
-create_exception!(pylaz, LazrsError, pyo3::exceptions::PyRuntimeError);
+create_exception!(lazrs, LazrsError, pyo3::exceptions::PyRuntimeError);
 
 fn as_bytes(object: &PyAny) -> PyResult<&[u8]> {
     let buffer = pyo3::buffer::PyBuffer::<u8>::get(object)?;


### PR DESCRIPTION
This fixes an edge case when using lazrs in a multiprocessing context, where pickling is involved. The message when an error occurs also contains a pickling error of `pylaz.LazrsError` and it can be confusing to the user what the real error message is.

```python
>>> import lazrs
>>> import pickle
>>> pickle.dumps(lazrs.LazrsError)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
_pickle.PicklingError: Can't pickle <class 'pylaz.LazrsError'>: import of module 'pylaz' failed
```
After the fix, the error is picklable:
```python
>>> import lazrs
>>> import pickle
>>> pickle.dumps(lazrs.LazrsError)
b'\x80\x04\x95\x18\x00\x00\x00\x00\x00\x00\x00\x8c\x05lazrs\x94\x8c\nLazrsError\x94\x93\x94.'
```

