### PR TITLE
Add Python 3.14 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+          python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v1
 
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v1
 
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
         arch: ['x86', 'x64']
 
     steps:
@@ -122,6 +122,10 @@ jobs:
           {
             version: '3.13',
             PYO3_CROSS_LIB_DIR: '/opt/python/cp313-cp313/lib'
+          },
+          {
+            version: '3.14',
+            PYO3_CROSS_LIB_DIR: '/opt/python/cp314-cp314/lib'
           }
         ]
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ version = "0.11.0"
 features = ["parallel"]
 
 [dependencies.pyo3]
-version = "0.26.0"
+version = "0.27.0"
 features = ["extension-module", "py-clone"]

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -112,7 +112,7 @@ impl std::io::Read for PyFileObject {
                         )
                     })?;
 
-                match object.downcast_bound::<pyo3::types::PyBytes>(py) {
+                match object.cast_bound::<pyo3::types::PyBytes>(py) {
                     Ok(py_bytes) => {
                         let read_bytes = py_bytes.as_bytes();
                         let shortest = std::cmp::min(buf.len(), read_bytes.len());


### PR DESCRIPTION
It would be nice to have 3.14 wheels on PyPI. I simply added `3.14` to the CI matrix. The build passes on my fork, but I have no fundamental understanding of the Rust toolchain.